### PR TITLE
Changed ports in docker-compose due to security purpose

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -29,7 +29,7 @@ services:
             PGADMIN_DEFAULT_EMAIL: ${PGADMIN_USER}
             PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD}
         ports:
-            - "5050:80"
+            - "127.0.0.1:5050:80"
         volumes:
             # Don't forget to set owner:group for this dir as 5050:5050
             # (sudo chown -R 5050:5050 <this path>)


### PR DESCRIPTION
It would be much more secure to include the localhost IP address to prevent access from outside. 

https://docs.docker.com/network/#published-ports